### PR TITLE
Fix extension typo in Introduction section

### DIFF
--- a/_introduction/02-plugin-bundles.md
+++ b/_introduction/02-plugin-bundles.md
@@ -34,7 +34,7 @@ Bundles contain a `manifest.json` file, one or more `.cocoascript` files (contai
 Here’s an example:
 
 ```
-mrwalker.sketchpluginbundle
+mrwalker.sketchplugin
   Contents/
     Sketch/
       manifest.json

--- a/_introduction/04-legacy-plugins.md
+++ b/_introduction/04-legacy-plugins.md
@@ -33,7 +33,7 @@ Commands in scripts with a `.cocoascript` file extension and an `onRun` command 
 For a bundle like this:
 
 ```
-Select Shapes.sketchpluginbundle
+Select Shapes.sketchplugin
   Contents/
     Sketch/
       manifest.json


### PR DESCRIPTION
The docs reflect that `.sketchpluginbundle` is an available extension for Sketch plugins but the only available extension for plugins is `.sketchplugin`