### PR TITLE
Ensure scripts in 'manifest.json' have the correct filepaths

### DIFF
--- a/_introduction/02-plugin-bundles.md
+++ b/_introduction/02-plugin-bundles.md
@@ -80,12 +80,12 @@ Here’s an example:
     {
       "name": "Circles",
       "identifier": "circles",
-      "script": "Select Circles.js"
+      "script": "Select Circles.cocoascript"
     },
     {
       "name": "Rectangles",
       "identifier": "rectangles",
-      "script": "Select Rectangles.js"
+      "script": "Select Rectangles.cocoascript"
     }
   ],
   "menu": {


### PR DESCRIPTION
Previously there was some inconsistency between the filepaths in the folder
structure and the `manifest.json` file; the scripts had the `.js` extension in
directory structure example, but `.cocoascript` in `manifest.json`.

This commit ensures that the scripts paths in `manifest.json` match up with the
filepaths according to the folder structure.

Hopefully this will make the guide slightly easier to follow.