### PR TITLE
Replace deprecated method in code sample

### DIFF
--- a/_code-examples/06-third-party-integrations.md
+++ b/_code-examples/06-third-party-integrations.md
@@ -57,7 +57,7 @@ To do that, we'll create a file called `hello.js` with this content
 ```
 var codeToRun = "context.document.showMessage('Hello, World!')"
 var sketchApp = COScript.app("Sketch")
-sketchApp.delegate().runPluginScript(codeToRun)
+sketchApp.delegate().runPluginScript_name(codeToRun, "coscript Demo")
 ```
 
 Now launch Sketch, make sure a document window is open, and run this line of code:


### PR DESCRIPTION
Using AppController's runPluginScript() method throws a deprecation warning in Console.app (at least in Sketch 3.6.1):
Sketch[24454]: Deprecated. Call runPluginScript:name with a nice descriptive name for your script instead

Documentation for AppController class at http://developer.sketchapp.com/reference/AppController/ doesn't mention this method as well, probably for the same reason.