### PR TITLE
Replace MSLayerGroup.addLayer with MSLayerGroup.addLayers as the form…

### DIFF
--- a/_reference/MSLayerGroup.md
+++ b/_reference/MSLayerGroup.md
@@ -26,9 +26,9 @@ Available in Sketch 3.4 and below, removed in Sketch 3.5 (see `resizeToFitChildr
 
 Added in Sketch 3.5. Resizes the group to fit around all of its sub-layers. `option` is either 0 (MSLayerGroupResizeOptionLayerOnly) or 1 (MSLayerGroupResizeOptionResizeParentUponRectChange).
 
-### addLayer:
+### addLayers:(NSArray)layers
 
-Add a layer to this group.
+Add layers to this group.
 
 ### removeLayer:
 


### PR DESCRIPTION
…er does not exist anymore.

In Sketch 3.7 the former method does not exist.
Most likely it has been removed some time ago, but I am not sure in which version exactly.

Does anyone know?