### PR TITLE
Fix typo in hello-world example

### DIFF
--- a/examples/plugins/hello-world.html
+++ b/examples/plugins/hello-world.html
@@ -98,7 +98,7 @@ we want to execute  a javascript handler called <code>onRun</code>.</p>
           </div>
           <p>We are passed a context variable when we’re run.
 This is a dictionary containing a reference to the document,
-the current selection, the plugin, curren URL and more.</p>
+the current selection, the plugin, current URL and more.</p>
 
         </div>
         


### PR DESCRIPTION
`curren URL` to `current URL`