### PR TITLE
Fix related class links

### DIFF
--- a/_layouts/sidebar-page.html
+++ b/_layouts/sidebar-page.html
@@ -68,7 +68,7 @@ layout: base
           <h2 class="h5">Related classes:</h2>
           <ul>
             {% for rel in page.rels %}
-            <li><a href="/reference/{{rel}}/">{{ rel }}</a></li>
+            <li><a href="/reference/class/{{rel}}/">{{ rel }}</a></li>
             {% endfor %}
           </ul>
           {% endif %}


### PR DESCRIPTION
Links for related class links are broken (see [the related classes at the bottom of MSLayerGroup](http://developer.sketchapp.com/reference/class/MSLayerGroup/) for an example). This fixes them!