### PR TITLE
Corrected JS filename

### DIFF
--- a/_generated-plugins/hello-world.html
+++ b/_generated-plugins/hello-world.html
@@ -41,7 +41,7 @@ look something like this:</p>
      Contents/
        Sketch/
          manifest.json
-         script.js
+         hello-world.js
 </code></pre><h2 id="manifest">Manifest</h2>
 <p>The plugin needs a <code>manifest.json</code> file. This tells Sketch which menu items your plugin supplies,
 as well as giving some general information about the plugin such as its name, author, and so on.</p>


### PR DESCRIPTION
The filename of the JS file in the tutorial (hello-world.js) didn't match the file structure at the beginning (script.js).